### PR TITLE
Add support for auto-copying binding redirects to web.config. Close #2

### DIFF
--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
@@ -18,6 +18,11 @@
     <ProjectCapability Include="SupportsSystemWeb" />
   </ItemGroup>
 
+
+  <PropertyGroup>
+    <OverwriteAppConfigWithBindingRedirects Condition="'$(OverwriteAppConfigWithBindingRedirects)'==''">false</OverwriteAppConfigWithBindingRedirects>
+  </PropertyGroup>
+
   <!-- Default item includes -->
   <Import Project="MSBuild.SDK.SystemWeb.DefaultItems.props" />
   

--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
@@ -22,6 +22,31 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
 
+  <Target Name="UpdateConfigWithBindingRedirects" AfterTargets="AfterBuild" Condition="'$(OverwriteAppConfigWithBindingRedirects)'=='true'">
+    <ItemGroup>
+      <_DllConfig Remove="@(_DllConfig)" />
+      <_AppConfig Remove="@(_AppConfig)" />
+      <_ConfigFile Remove="@(_ConfigFileHash)" />
+      <_DllConfig Include="$(OutDir)$(AssemblyName).dll.config" />
+      <_AppConfig Include="web.config" />
+    </ItemGroup>
+    <GetFileHash Files="@(_DllConfig)">
+      <Output TaskParameter="Hash" PropertyName="_DllConfigHash" />
+      <Output TaskParameter="Items" ItemName="_DllConfigFileHash" />
+    </GetFileHash>
+    <GetFileHash Files="@(_AppConfig)">
+      <Output TaskParameter="Hash" PropertyName="_AppConfigHash" />
+      <Output TaskParameter="Items" ItemName="_AppConfigFileHash" />
+    </GetFileHash>
+    <ItemGroup>
+      <_ConfigFileHash Include="@(_DllConfigFileHash)" />
+      <_ConfigFileHash Include="@(_AppConfigFileHash)" />
+    </ItemGroup>
+    <Message Text="%(_ConfigFileHash.Identity): %(_ConfigFileHash.FileHash)" />
+    <Warning Text="Replacing web.config due to changes during compile - This should clear warning MSB3276 on next compile" File="web.config" Condition="'$(_DllConfigHash)'!='$(_AppConfigHash)'" />
+    <Copy SourceFiles="$(OutDir)$(AssemblyName).dll.config" DestinationFiles="web.config" Condition="'$(_DllConfigHash)'!='$(_AppConfigHash)'" />
+  </Target>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" />
 </Project>


### PR DESCRIPTION
New property `OverwriteAppConfigWithBindingRedirects` which defaults to false.