### PR TITLE
Adjusted Various Default Item Globbing Strategies

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,10 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DefaultItemExcludes>*log</DefaultItemExcludes>
-    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
-    <LangVersion>Latest</LangVersion>
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(MSBuildThisFileDirectory)packages\</PackageOutputPath>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
+    <RepoRootDirectoryPath>$(MSBuildThisFileDirectory)</RepoRootDirectoryPath>
   </PropertyGroup>
+
 </Project>

--- a/Directory.Build.Targets
+++ b/Directory.Build.Targets
@@ -29,16 +29,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="Sdk\**"
-          Pack="true"
-          PackagePath="Sdk\" />
-    <None Include="README.md" Condition="EXISTS('README.md')" />
-    <None Include="$(PackageLicensePath)"
-          Pack="true"
-          PackagePath="$(PackageLicenseFile)"
-          Visible="false" />
-  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />

--- a/MSBuild.SDK.SystemWeb.sln
+++ b/MSBuild.SDK.SystemWeb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.0.31912.275
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuild.SDK.SystemWeb", "src\MSBuild.SDK.SystemWeb\MSBuild.SDK.SystemWeb.csproj", "{D9DD78A9-4E97-4339-B809-6A2CC28B071A}"
 EndProject
@@ -56,6 +56,18 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleRazorLibrary", "samples\RazorLibrary\ExampleRazorLibrary\ExampleRazorLibrary.csproj", "{A699C2E4-43C7-409D-BC2B-1197E61FD9BC}"
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "ExampleRazorLibraryVB", "samples\RazorLibrary\ExampleRazorLibraryVB\ExampleRazorLibraryVB.vbproj", "{AD80B3C1-916E-4E46-BF07-6AEE8606AB00}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{C0B6F25C-A27D-453E-8366-9347713B9BC6}"
+	ProjectSection(SolutionItems) = preProject
+		samples\Directory.Build.props = samples\Directory.Build.props
+		samples\Directory.Build.targets = samples\Directory.Build.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{54787AA7-0AF5-45FF-A3E2-BB0FB3365013}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,6 +127,8 @@ Global
 		{3BC6F60B-0AC5-4300-9DFD-4B65D97FFD12} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
 		{A699C2E4-43C7-409D-BC2B-1197E61FD9BC} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
 		{AD80B3C1-916E-4E46-BF07-6AEE8606AB00} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
+		{C0B6F25C-A27D-453E-8366-9347713B9BC6} = {4A37969E-D8DB-4AAA-A382-D6E733B6185B}
+		{54787AA7-0AF5-45FF-A3E2-BB0FB3365013} = {B91408ED-7A59-4890-8CB2-5A011DD62B1C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5FBE1CF-A73C-4BFD-BBA5-95488B7930D9}

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /samples directory specific Directory.Build.props
+              We will set values specifically for the samples projects that do not apply to the nugetPackage projects
+              
+              We will also look to import the "repo" Directory.Build.props file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildPropsPath>
+  </PropertyGroup>
+    <Import Label="Look for a higher/repo version of this file and import it"
+          Project="$(RepoDirectoryBuildPropsPath)" 
+          Condition="exists('$(RepoDirectoryBuildPropsPath)')"/>
+
+
+</Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /samples directory specific Directory.Build.targets
+              We will set values specifically for the samples projects that do not apply to the nugetPackage projects
+              
+              We will also look to import the "repo" Directory.Build.targets file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildTargetsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildTargetsPath>
+  </PropertyGroup>
+  <Import Label="Look for a higher/repo version of this file and import it"
+        Project="$(RepoDirectoryBuildTargetsPath)"
+        Condition="exists('$(RepoDirectoryBuildTargetsPath)')"/>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,37 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /src directory specific Directory.Build.props
+              We will set values specifically for the nugetPackage projects that do not apply to the sample projects
+              
+              We will also look to import the "repo" Directory.Build.props file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildPropsPath>
+  </PropertyGroup>
+    <Import Label="Look for a higher/repo version of this file and import it"
+          Project="$(RepoDirectoryBuildPropsPath)" 
+          Condition="exists('$(RepoDirectoryBuildPropsPath)')"/>
+
+
+  <PropertyGroup>
+    <DefaultItemExcludes>*log</DefaultItemExcludes>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <LangVersion>Latest</LangVersion>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(RepoRootDirectoryPath)packages\</PackageOutputPath>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
+  </PropertyGroup>
+
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="Sdk\**"
+          Pack="true"
+          PackagePath="Sdk\" />
+    <None Include="README.md" Condition="EXISTS('README.md')" />
+    <None Include="$(PackageLicensePath)"
+          Pack="true"
+          PackagePath="$(PackageLicenseFile)"
+          Visible="false" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /src directory specific Directory.Build.targets
+              We will set values specifically for the nugetPackage projects that do not apply to the sample projects
+              
+              We will also look to import the "repo" Directory.Build.targets file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildTargetsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildTargetsPath>
+  </PropertyGroup>
+  <Import Label="Look for a higher/repo version of this file and import it"
+        Project="$(RepoDirectoryBuildTargetsPath)"
+        Condition="exists('$(RepoDirectoryBuildTargetsPath)')"/>
+
+
+</Project>

--- a/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
@@ -1,76 +1,203 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <!-- EnableWebFormsDefaultItems follows EnableSystemWebDefaultItems and adds WebForms items as content - Closes #24 -->
-  <PropertyGroup>
-    <EnableWebFormsDefaultItems Condition="'$(EnableWebFormsDefaultItems)'==''">$(EnableDefaultItems)</EnableWebFormsDefaultItems>
-    <EnableWebFormsDefaultItems Condition="'$(EnableWebFormsDefaultItems)'==''">true</EnableWebFormsDefaultItems> <!-- If $(EnableDefaultItems) is undefined-->
-  </PropertyGroup>
   
-  <ItemGroup Condition="'$(EnableWebFormsDefaultItems)'=='true'">
-    <Content Include="Web.config" />
-    <_WebConfigConfigurations Include="$(Configurations)" />
-    <None Include="@(_WebConfigConfigurations->'Web.%(Identity).config')">
-      <DependentUpon>Web.config</DependentUpon>
-    </None>
-    <None Include="Web.BindingRedirects.config" Condition="EXISTS('Web.BindingRedirects.config')">
-      <DependentUpon>Web.config</DependentUpon>
-    </None>
-    <Content Include="Web.*.config" Exclude="@(None)">
-      <DependentUpon>Web.config</DependentUpon>
-    </Content>
-  </ItemGroup>
-
-  <!-- Support App_GlobalResources folder
-      https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/3
-      https://github.com/dotnet/project-system/issues/2670#issuecomment-820581558
-   -->
-  <ItemGroup>
-    <EmbeddedResource Remove="App_GlobalResources\*.resx" />
-    <Content Include="App_GlobalResources\*.resx">
-      <Generator>GlobalResourceProxyGenerator</Generator>
-      <LastGenOutput>%(Filename).Designer$(DefaultLanguageSourceExtension)</LastGenOutput>
-    </Content>
-  </ItemGroup>
-  <ItemGroup Condition="'$(Language)'=='C#'">
-    <Compile Update="App_GlobalResources\*.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)', '\.Designer$', '')).resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup Condition="'$(Language)'=='VB'">
-    <Compile Update="App_GlobalResources\*.Designer.vb">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)', '\.Designer$', '')).resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <!-- Support App_Code folder https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/4 -->
-  <ItemGroup Condition="'$(Language)'=='VB'">
-    <Compile Remove="App_Code\*.vb" />
-    <Content Include="App_Code\*.vb" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(Language)'=='C#'">
-    <Compile Remove="App_Code\*.cs" />
-    <Content Include="App_Code\*.cs" />
-  </ItemGroup>
-
+  
   <!-- Exclude node_modules and similar folders from default globbing - Closes #19 -->
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\node_modules\**;node_modules\**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\jspm_packages\**;jspm_packages\**</DefaultItemExcludes>
     <DefaultItemExcludes>$(DefaultItemExcludes);**\bower_components\**;bower_components\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.binlog</DefaultItemExcludes>
   </PropertyGroup>
 
-  <!-- Include WebForms items as content -->
-  <ItemGroup Condition="'$(EnableWebFormsDefaultItems)'=='true'">
-    <Content Include="**\*.asax" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.ascx" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.ashx" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.asmx" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.aspx" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.master" Exclude="$(DefaultWebFormsItemExcludes)" />
-    <Content Include="**\*.svc" Exclude="$(DefaultWebFormsItemExcludes)" />
+  
+  
+  
+  
+  
+  
+  
+  <!--  *******************************************************************************************************
+              This ItemGroup is Inspired by Sdk.Razor.CurrentVersion.props and Sdk.Razor.StaticAssets.ProjectSystem.props
+        Remove things from the various ItemGroup that should instead be treated as Content
+        Include items from the various AspNet2.0 folders)
+
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+  <!-- 
+      Support App_Code folder https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/4
+      Support App_GlobalResources folder
+      https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/3
+      https://github.com/dotnet/project-system/issues/2670#issuecomment-820581558
+   -->    
+    <DefaultAspNetFolderItemFilter>App_Code/**/*.cs;App_Code/**/*.vb</DefaultAspNetFolderItemFilter>
+    <DefaultAspNetFolderItemFilter>$(DefaultAspNetFolderItemFilter);App_Data/**/*.*</DefaultAspNetFolderItemFilter>
+    <DefaultAspNetFolderItemFilter>$(DefaultAspNetFolderItemFilter);App_Browsers/**/*.*</DefaultAspNetFolderItemFilter>
+    <DefaultAspNetFolderItemFilter>$(DefaultAspNetFolderItemFilter);App_Themes/**/*.*</DefaultAspNetFolderItemFilter>
+    <DefaultAspNetFolderItemFilter>$(DefaultAspNetFolderItemFilter);App_GlobalResources/**/*.resx</DefaultAspNetFolderItemFilter>
+    <DefaultAspNetFolderItemFilter>$(DefaultAspNetFolderItemFilter);**/App_LocalResources/**/*.resx</DefaultAspNetFolderItemFilter>
+
+    <!--
+      App_WebReferences AspNet2.0 folder nolonger supported in Web Application Project
+      However there are also some other folders "Connected Services" and "Web References"... and these might need to remain manual 
+    -->
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(EnableDefaultItems)'=='true' And '$(EnableDefaultAspNet20Items)'=='true' And '$(EnableDefaultContentItems)' == 'true' "
+             Label="Explicitly include content from ASPNet 2.0 folders in case people are still using them">
+    <_AspNetFolderArtifacts Include="$(DefaultAspNetFolderItemFilter)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    
+    <Compile Remove="@(_AspNetFolderArtifacts)" Condition=" '$(EnableDefaultCompileItems)'=='true' " />
+    <None Remove="@(_AspNetFolderArtifacts)" Condition=" '$(EnableDefaultNoneItems)'=='true' " />
+    <EmbeddedResource Remove="@(_AspNetFolderArtifacts)" Condition=" '$(EnableDefaultNoneItems)'=='true' " />
+  
+    <_AspNetFolderArtifacts Update="App_GlobalResources/**/*.resx">
+      <Generator>GlobalResourceProxyGenerator</Generator>
+      <LastGenOutput>%(Filename).Designer$(DefaultLanguageSourceExtension)</LastGenOutput>
+    </_AspNetFolderArtifacts> 
+
+    <Content Include="@(_AspNetFolderArtifacts)" />
+    
+      
+    <Compile Update="App_GlobalResources/**/*.Designer$(DefaultLanguageSourceExtension)" Condition=" '$(EnableDefaultCompileItems)'=='true' " >
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>$([System.Text.RegularExpressions.Regex]::Replace('%(Filename)', '\.Designer$', '')).resx</DependentUpon>
+    </Compile>  
   </ItemGroup>
+
+
+  
+  
+  
+  
+  
+  
+  <!--  *******************************************************************************************************
+              This ItemGroup is Inspired by Sdk.Razor.CurrentVersion.props and Sdk.Razor.StaticAssets.ProjectSystem.props
+        Remove things from the None ItemGroup that should be treated as WebForms
+        Include all known WebFormsExtensions
+
+        ******************************************************************************************************* -->
+  <!-- EnableWebFormsDefaultItems follows EnableSystemWebDefaultItems and adds WebForms items as content - Closes #24 -->
+  <!-- DefaultWebFormsItemExcludes prevents including build and publish outputs - Closes #25 - changing exclusion to use the default exclusion mechanisms -->
+  <PropertyGroup>
+    <DefaultWebFormsItemFilter>**/*.asax</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.ascx</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.ashx</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.asmx</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.aspx</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.master</DefaultWebFormsItemFilter>
+    <DefaultWebFormsItemFilter>$(DefaultWebFormsItemFilter);**/*.svc</DefaultWebFormsItemFilter>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" '$(EnableDefaultItems)'=='true' And '$(EnableWebFormsDefaultItems)'=='true' And '$(EnableDefaultContentItems)' == 'true' "
+             Label="Explicitly include WebForms content under the assumption that they have been converted to codebehind and are not codefile">
+    <_WebFormsArtifacts Include="$(DefaultWebFormsItemFilter)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    
+    <None Remove="@(_WebFormsArtifacts)" Condition=" '$(EnableDefaultNoneItems)'=='true' "/>
+
+    <Content Include="@(_WebFormsArtifacts)" />
+  </ItemGroup>
+
+  
+  
+  
+  
+  
+  
+  <!--  *******************************************************************************************************
+              This ItemGroup is Inspired by Sdk.Razor.CurrentVersion.props and Sdk.Razor.StaticAssets.ProjectSystem.props
+        Remove things from the None ItemGroup that should be treated as Content
+        Include all Mvc Razor views (.cshtml and/or .vbhtml since these are ASPNet runtime compiled... even if compiled at build time, they can be intermixed)
+
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <DefaultMvcRazorItemFilter>**/*.cshtml</DefaultMvcRazorItemFilter>
+    <DefaultMvcRazorItemFilter>$(DefaultMvcRazorItemFilter);**/*.vbhtml</DefaultMvcRazorItemFilter>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" '$(EnableDefaultItems)'=='true' And '$(EnableDefaultRazorItems)'=='true' And '$(EnableDefaultContentItems)' == 'true' ">
+    <_RazorArtifacts Include="$(DefaultMvcRazorItemFilter)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+
+    <None Remove="$(DefaultMvcRazorItemFilter)" Condition=" '$(EnableDefaultNoneItems)'=='true' "/>
+
+    <Content Include="@(_RazorArtifacts)" />
+  </ItemGroup>
+
+  
+  
+  
+  
+  
+  
+  <!--  *******************************************************************************************************
+              This ItemGroup is Inspired by Sdk.Razor.CurrentVersion.props and Sdk.Razor.StaticAssets.ProjectSystem.props
+        Remove things from the None ItemGroup that should be treated as Content
+        Include all things that are not MsBuild Compile or EmbeddedResource
+
+        ******************************************************************************************************* -->  
+  <ItemGroup Condition=" '$(EnableDefaultItems)'=='true' And '$(EnableDefaultContentItems)' == 'true' And '$(EnableDefaultWebStaticItems)' == 'true' ">
+    <_WebStaticArtifacts Include="@(None)" Condition=" '$(EnableDefaultNoneItems)'=='true' " />
+    <_WebStaticArtifacts Include="**/*"
+                         Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);@(Compile);@(EmbeddedResource);@(Content)"
+                         Condition=" '$(EnableDefaultNoneItems)'!='true' " />
+
+    <_WebStaticArtifacts Update="Web.*.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </_WebStaticArtifacts>    
+    
+    <None Remove="@(_WebStaticArtifacts)" Condition=" '$(EnableDefaultNoneItems)'=='true' " />
+
+    <Content Include="@(_WebStaticArtifacts)" />
+
+  </ItemGroup>  
+
+  
+  
+<!--  *******************************************************************************************************
+              This item Group mimics the Microsoft.NET.Sdk.Web.DefaultItems.props
+        We want to let the web application know that many items in the project are just to organize a web project
+          Should not be copied to publish directory, etc
+        We want this to be the "Last" includer of content... at least the last of those of this SDK type
+        ******************************************************************************************************* -->
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true'
+             And '$(EnableDefaultContentItems)' == 'true'
+             And '$(EnableDefaultNoneItems)' == 'true'
+             And '$(AppDesignerFolder)' != ''">
+
+    <_WebConfigConfigurations Include="$(Configurations)" />
+    <_WebToolingArtifacts Include="@(_WebConfigConfigurations->'Web.%(Identity).config')">
+      <DependentUpon>Web.config</DependentUpon>
+    </_WebToolingArtifacts>
+
+
+
+    <_WebToolingArtifacts Include="$(AppDesignerFolder)\launchSettings*.json;
+                          $(AppDesignerFolder)\serviceDependencies*.json;
+                          $(AppDesignerFolder)\serviceDependencies.*.json;
+                          $(AppDesignerFolder)\ServiceDependencies\**;
+                          $(AppDesignerFolder)\PublishProfiles\**;
+                          Web*.BindingRedirects.config"
+                          
+                          Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)"/>
+    <_WebToolingArtifacts Update="Web*.BindingRedirects.config">
+        <DependentUpon>Web.config</DependentUpon>
+    </_WebToolingArtifacts>
+    
+    <!-- Removing the tooling artifacts from all other globs and adding it to the none glob. This ensures that the
+         up-to-date check is unimpacted by the changes to the tooling artifacts -->
+    <None Remove="@(_WebToolingArtifacts)" />
+    <None Include="@(_WebToolingArtifacts)"
+          CopyToOutputDirectory="Never"
+          CopyToPublishDirectory="Never"
+          ExcludeFromSingleFile="true" />
+
+    <Content Remove="@(_WebToolingArtifacts)" />
+    <Compile Remove="@(_WebToolingArtifacts)" />
+    <EmbeddedResource Remove="@(_WebToolingArtifacts)" />
+
+    <!-- Keep track of the default content items for later to distinguish them from newly generated content items -->
+    <_ContentIncludedByDefault Remove="@(_ContentIncludedByDefault)" />
+    <_ContentIncludedByDefault Include="@(Content)" />
+
+  </ItemGroup>  
 </Project>

--- a/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.targets
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.targets
@@ -1,18 +1,19 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Exclude WebForms items from default items -->
-  <PropertyGroup Condition="'$(EnableWebFormsDefaultItems)'=='true'">
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.asax;*.asax</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.ascx;*.ascx</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.ashx;*.ashx</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.asmx;*.asmx</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.aspx;*.aspx</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.master;*.master</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);**\*.svc;*.svc</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);web.config;web.*.config</DefaultItemExcludes>
-    <!-- DefaultWebFormsItemExcludes prevents including build and publish outputs - Closes #25 -->
-    <DefaultWebFormsItemExcludes Condition="'$(DefaultWebFormsItemExcludes)'!=''">$(DefaultWebFormsItemExcludes);</DefaultWebFormsItemExcludes>
-    <DefaultWebFormsItemExcludes>$(DefaultWebFormsItemExcludes)$([MSBuild]::EnsureTrailingSlash($(OutputPath)))**</DefaultWebFormsItemExcludes>
-    <DefaultWebFormsItemExcludes Condition="'$(PackageLocation)'!=''">$(DefaultWebFormsItemExcludes);$([MSBuild]::EnsureTrailingSlash($(PackageLocation)))**</DefaultWebFormsItemExcludes>
-    <DefaultWebFormsItemExcludes Condition="'$(BaseIntermediateOutputPath)'!=''">$(DefaultWebFormsItemExcludes);$([MSBuild]::EnsureTrailingSlash($(BaseIntermediateOutputPath)))**</DefaultWebFormsItemExcludes>
-  </PropertyGroup>
+
+  <PropertyGroup>
+
+    <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)'==''">true</EnableDefaultContentItems>
+
+    <EnableDefaultAspNet20Items Condition="'$(EnableDefaultAspNet20Items)' == ''">true</EnableDefaultAspNet20Items>
+
+    <!-- EnableWebFormsDefaultItems follows EnableSystemWebDefaultItems and adds WebForms items as content - Closes #24 -->
+    <EnableWebFormsDefaultItems Condition="'$(EnableWebFormsDefaultItems)'==''">$(EnableDefaultItems)</EnableWebFormsDefaultItems>
+    <EnableWebFormsDefaultItems Condition="'$(EnableWebFormsDefaultItems)'==''">true</EnableWebFormsDefaultItems>
+    <!-- If $(EnableDefaultItems) is undefined-->
+
+    <EnableDefaultRazorItems Condition="'$(EnableDefaultRazorItems)'==''">true</EnableDefaultRazorItems>
+
+    <EnableDefaultWebStaticItems Condition="'$(EnableDefaultWebStaticItems)'==''">true</EnableDefaultWebStaticItems>
+  </PropertyGroup>  
+  
 </Project>


### PR DESCRIPTION
The Directory.Build.props/targets was split to differently effect the /src and /samples directories.  This allows setting EnableDefaultNoneItems == true for just the nuget package projects under the /src directory.

Also the DefaultItems.props/targets was adjusted to mimic  the .netcore web application style of globbing.