### PR TITLE
Splitting Directory.Build props/targets files to differentiate betwee…

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,10 +1,6 @@
 <Project>
   <PropertyGroup>
-    <DefaultItemExcludes>*log</DefaultItemExcludes>
-    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
-    <LangVersion>Latest</LangVersion>
-    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(MSBuildThisFileDirectory)packages\</PackageOutputPath>
-    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
+    <RepoRootDirectoryPath>$(MSBuildThisFileDirectory)</RepoRootDirectoryPath>
   </PropertyGroup>
+
 </Project>

--- a/Directory.Build.Targets
+++ b/Directory.Build.Targets
@@ -29,16 +29,7 @@
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsPackable)' == 'true'">
-    <None Include="Sdk\**"
-          Pack="true"
-          PackagePath="Sdk\" />
-    <None Include="README.md" Condition="EXISTS('README.md')" />
-    <None Include="$(PackageLicensePath)"
-          Pack="true"
-          PackagePath="$(PackageLicenseFile)"
-          Visible="false" />
-  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="All" />

--- a/MSBuild.SDK.SystemWeb.sln
+++ b/MSBuild.SDK.SystemWeb.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.0.31912.275
+VisualStudioVersion = 17.1.32210.238
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSBuild.SDK.SystemWeb", "src\MSBuild.SDK.SystemWeb\MSBuild.SDK.SystemWeb.csproj", "{D9DD78A9-4E97-4339-B809-6A2CC28B071A}"
 EndProject
@@ -56,6 +56,18 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleRazorLibrary", "samples\RazorLibrary\ExampleRazorLibrary\ExampleRazorLibrary.csproj", "{A699C2E4-43C7-409D-BC2B-1197E61FD9BC}"
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "ExampleRazorLibraryVB", "samples\RazorLibrary\ExampleRazorLibraryVB\ExampleRazorLibraryVB.vbproj", "{AD80B3C1-916E-4E46-BF07-6AEE8606AB00}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{C0B6F25C-A27D-453E-8366-9347713B9BC6}"
+	ProjectSection(SolutionItems) = preProject
+		samples\Directory.Build.props = samples\Directory.Build.props
+		samples\Directory.Build.targets = samples\Directory.Build.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{54787AA7-0AF5-45FF-A3E2-BB0FB3365013}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -115,6 +127,8 @@ Global
 		{3BC6F60B-0AC5-4300-9DFD-4B65D97FFD12} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
 		{A699C2E4-43C7-409D-BC2B-1197E61FD9BC} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
 		{AD80B3C1-916E-4E46-BF07-6AEE8606AB00} = {26AD80FE-B7CD-457A-B03A-90A5B395759E}
+		{C0B6F25C-A27D-453E-8366-9347713B9BC6} = {4A37969E-D8DB-4AAA-A382-D6E733B6185B}
+		{54787AA7-0AF5-45FF-A3E2-BB0FB3365013} = {B91408ED-7A59-4890-8CB2-5A011DD62B1C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5FBE1CF-A73C-4BFD-BBA5-95488B7930D9}

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /samples directory specific Directory.Build.props
+              We will set values specifically for the samples projects that do not apply to the nugetPackage projects
+              
+              We will also look to import the "repo" Directory.Build.props file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildPropsPath>
+  </PropertyGroup>
+    <Import Label="Look for a higher/repo version of this file and import it"
+          Project="$(RepoDirectoryBuildPropsPath)" 
+          Condition="exists('$(RepoDirectoryBuildPropsPath)')"/>
+
+
+</Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /samples directory specific Directory.Build.targets
+              We will set values specifically for the samples projects that do not apply to the nugetPackage projects
+              
+              We will also look to import the "repo" Directory.Build.targets file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildTargetsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildTargetsPath>
+  </PropertyGroup>
+  <Import Label="Look for a higher/repo version of this file and import it"
+        Project="$(RepoDirectoryBuildTargetsPath)"
+        Condition="exists('$(RepoDirectoryBuildTargetsPath)')"/>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,37 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /src directory specific Directory.Build.props
+              We will set values specifically for the nugetPackage projects that do not apply to the sample projects
+              
+              We will also look to import the "repo" Directory.Build.props file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildPropsPath>
+  </PropertyGroup>
+    <Import Label="Look for a higher/repo version of this file and import it"
+          Project="$(RepoDirectoryBuildPropsPath)" 
+          Condition="exists('$(RepoDirectoryBuildPropsPath)')"/>
+
+
+  <PropertyGroup>
+    <DefaultItemExcludes>*log</DefaultItemExcludes>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <LangVersion>Latest</LangVersion>
+    <PackageOutputPath Condition="'$(PackageOutputPath)'==''">$(RepoRootDirectoryPath)packages\</PackageOutputPath>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+    <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
+  </PropertyGroup>
+
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="Sdk\**"
+          Pack="true"
+          PackagePath="Sdk\" />
+    <None Include="README.md" Condition="EXISTS('README.md')" />
+    <None Include="$(PackageLicensePath)"
+          Pack="true"
+          PackagePath="$(PackageLicenseFile)"
+          Visible="false" />
+  </ItemGroup>
+  
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+  <!--  *******************************************************************************************************
+              This is the /src directory specific Directory.Build.targets
+              We will set values specifically for the nugetPackage projects that do not apply to the sample projects
+              
+              We will also look to import the "repo" Directory.Build.targets file
+        ******************************************************************************************************* -->
+  <PropertyGroup>
+    <RepoDirectoryBuildTargetsPath>$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))</RepoDirectoryBuildTargetsPath>
+  </PropertyGroup>
+  <Import Label="Look for a higher/repo version of this file and import it"
+        Project="$(RepoDirectoryBuildTargetsPath)"
+        Condition="exists('$(RepoDirectoryBuildTargetsPath)')"/>
+
+
+</Project>


### PR DESCRIPTION
…n sample and nuget-package projects

Created "Directory" level props/targets files for the Samples\ and src\ directories, that each contain the properties/items that should be specific to each area

Additionally created a "Look Upwards" chain to import the Repo Root level Directory.Build.(props/targets) so that concepts that should apply to all projects in the repo can be set at the root level