### PR TITLE
Make config transforms available in web deploy package

### DIFF
--- a/samples/ExampleFullWebApplication/Web.StagingEnvironment.config
+++ b/samples/ExampleFullWebApplication/Web.StagingEnvironment.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0"?>
+
+<!-- For more information on using Web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=301874 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator
+    finds an attribute "name" that has a value of "MyDB".
+
+    <connectionStrings>
+      <add name="MyDB"
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire
+      <customErrors> section of your Web.config file.
+      Note that because there is only one customErrors section under the
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
@@ -15,9 +15,12 @@
     <None Include="Web.BindingRedirects.config" Condition="EXISTS('Web.BindingRedirects.config')">
       <DependentUpon>Web.config</DependentUpon>
     </None>
-    <Content Include="Web.*.config" Exclude="@(None)">
-      <DependentUpon>Web.config</DependentUpon>
-    </Content>
+    
+    <!-- Altered web.*.config inclusion so these items will be in the WebDeploy Package 
+    Where they can be used at deployment time for Environment Specific Transformation
+    https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/43 
+    -->
+    <Content Include="Web.*.config" Exclude="@(None)" />
   </ItemGroup>
 
   <!-- Support App_GlobalResources folder

--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
@@ -16,6 +16,16 @@
     <ProjectCapability Include="LegacyRazorEditor" />
   </ItemGroup>
 
+  <!-- Support for making items "appear" nested in the solution explorer even when the DependentUpon metadata not set
+    https://github.com/CZEMacLeod/MSBuild.SDK.SystemWeb/issues/43 
+    Added because desire to support Environment Specific Transformation of config files
+  -->
+  <ItemGroup
+    Condition=" '$(BuildingInsideVisualStudio)' == 'true' and '$(VisualStudioVersion)' != '' and '$(VisualStudioVersion)' >= '15.0' "
+    Label="This Capability is included by the .net core web projects and tells the solution Explorer to render certain items as nesting under others ">
+    <ProjectCapability Include="DynamicFileNesting"/>
+  </ItemGroup>
+
   <Import Project="MSBuild.SDK.SystemWeb.DefaultPackages.props" />
   <!-- Default item includes -->
   <Import Project="MSBuild.SDK.SystemWeb.DefaultItems.props" />


### PR DESCRIPTION
Proposal that make config transform files available in the web deploy package, and also continues have them "appear" nested underneath the main Web.config

This is related to to Issue #43 and Discussion #40