### PR TITLE
Update Microsoft.CodeDom.Providers.DotNetCompilerPlatform - closes #59

### DIFF
--- a/docs/RazorLibrary.md
+++ b/docs/RazorLibrary.md
@@ -66,10 +66,12 @@ For more information see
 
 ### Common Packages
 
-| Package | Default Version | Property |
-| ------- | --------------- | -------- |
-| `Microsoft.Net.Compilers.Toolset` | 4.5.0 | `MicrosoftNetCompilersToolset_Version` |
-| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | 3.6.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| Package | Target Framework | Default Version | Property |
+| ------- | ---------------- | --------------- | -------- |
+| `Microsoft.Net.Compilers.Toolset` | Any | 4.5.0 | `MicrosoftNetCompilersToolset_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | <4.6.2 | 3.6.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | >=4.6.2 and < 4.7.2 | 3.11.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | >=4.7.2 | 4.1.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
 
 ### Specific Packages
 

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -37,7 +37,7 @@ You can also use the [templates](Templates.md) to easily create new projects.
 | -------- | ------------- | ----------- |
 | `ExcludeSDKDefaultPackages` | false | Do not include the default packages `Microsoft.Net.Compilers.Toolset` and `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` |
 | `ApplySDKDefaultPackageVersions` | true* | Apply default version numbers to packages unless using a Central Package Management system |
-| `GeneratedBindingRedirectsAction` | None | Set the desired default behavior of what to do with SuggestedBindingRedirects if not yet set.<br>See [automatically generated binding redirects](Binding_Redirects/Autogenerating-Binding-Redirects.md)<br><ul><li>`None` - Do nothing except show the warning</li><li>`Preview` - Creates new Web.BindingRedirects.config file showing proposed changes</li><li>`Overwrite` - Updates the $(AppConfig) aka web.config in the project root</li></ul> |
+| `GeneratedBindingRedirectsAction` | None | Set the desired default behavior of what to do with SuggestedBindingRedirects if not yet set.<br>See [automatically generated binding redirects](Binding_Redirects/Autogenerating-Binding-Redirects.md)<br><ul><li>`None` - Do nothing except show the warning</li><li>`Preview` - Creates new Web.BindingRedirects.config file showing proposed changes</li><li>`Overwrite` - Updates the $(AppConfig) aka web.config in the project root and any `RazorAppConfigFiles` files</li></ul> |
 
 *Version numbers are not applied if you are using `Microsoft.Build.CentralPackageVersions` version 2.1.1 or higher. Remember to include the packages in your central package versions file.
 
@@ -52,6 +52,7 @@ You can also use the [templates](Templates.md) to easily create new projects.
 ** You will have to adjust your web.config to change the `system.codedom/compilers/compiler` `compilerOptions` attribute to set the langversion - it won't automatically use the `LangVersion` property from your project file.
 
 ### Deprecated Properties
+
 | Property | Default value | Description |
 | -------- | ------------- | ----------- |
 | `ExcludeASPNetCompilers` | false | Use `ExcludeSDKDefaultPackages` instead |
@@ -61,7 +62,9 @@ You can also use the [templates](Templates.md) to easily create new projects.
 
 ### Common Packages
 
-| Package | Default Version | Property |
-| ------- | --------------- | -------- |
-| `Microsoft.Net.Compilers.Toolset` | 4.5.0 | `MicrosoftNetCompilersToolset_Version` |
-| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | 3.6.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| Package | Target Framework | Default Version | Property |
+| ------- | ---------------- | --------------- | -------- |
+| `Microsoft.Net.Compilers.Toolset` | Any | 4.5.0 | `MicrosoftNetCompilersToolset_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | <4.6.2 | 3.6.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | >=4.6.2 and < 4.7.2 | 3.11.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |
+| `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` | >=4.7.2 | 4.1.0 | `MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version` |

--- a/src/MSBuild.SDK.SystemWeb.CommonFiles/Sdk/MSBuild.SDK.SystemWeb.Common.DefaultPackages.props
+++ b/src/MSBuild.SDK.SystemWeb.CommonFiles/Sdk/MSBuild.SDK.SystemWeb.Common.DefaultPackages.props
@@ -1,6 +1,10 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(ExcludeSDKDefaultPackages)'=='false'">
     <MicrosoftNetCompilersToolset_Version Condition="'$(MicrosoftNetCompilersToolset_Version)'==''">4.5.0</MicrosoftNetCompilersToolset_Version>
-    <MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version Condition="'$(MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version)'==''">3.6.0</MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version)'==''">
+    <MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version>3.6.0</MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version><!-- net 4.5 / 4.6 / 4.7.2+ -->
+    <MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.6.2')))) &gt;= 0">3.11.0</MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version><!-- net 4.6.2, 4.7.2+ -->
+    <MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('4.7.2')))) &gt;= 0">4.1.0</MicrosoftCodeDomProvidersDotNetCompilerPlatform_Version><!-- net 4.7.2+ -->
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The default version of `Microsoft.CodeDom.Providers.DotNetCompilerPlatform` now depends on your target framework version, and will automatically move to 3.11.0 or 4.1.0 if possible, and fallback to the previous value of 3.6.0 otherwise.

Closes #59, although this may need reworked when a better way to handle default versions is included based on #54 and #56.