### PR TITLE
Only include web.$(Configuration).config where xxxx exists on disk. Fixes #67

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
   },
     "msbuild-sdks": {
         "Microsoft.Build.NoTargets": "2.0.1",
-        "MSBuild.SDK.SystemWeb": "4.0.82",
-        "MSBuild.SDK.SystemWeb.RazorLibrary": "4.0.82"
+        "MSBuild.SDK.SystemWeb": "4.0.88",
+        "MSBuild.SDK.SystemWeb.RazorLibrary": "4.0.88"
     }
 }

--- a/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
@@ -9,13 +9,21 @@
   <ItemGroup Condition="'$(EnableWebFormsDefaultItems)'=='true'">
     <Content Include="Web.config" />
     <!-- web.*.config where * is a Configuration type (used for transforms) fixes #67 -->
-    <_WebConfigConfiguration Include="$(Configurations)" Exclude="@ExcludeWebConfigConfiguration" />
-    <_WebConfigConfigurationFiles Include="@(_WebConfigConfiguration->'Web.%(Identity).config')">
-      <DependentUpon>Web.config</DependentUpon>
-    </_WebConfigConfigurationFiles>
-    <None Include="@(_WebConfigConfigurationFiles->Exists())" />
+    <_WebConfigConfiguration Include="$(Configurations)" Exclude="@ExcludeWebConfigConfiguration">
+      <Configuration>%(Identity)</Configuration>
+    </_WebConfigConfiguration>
+    <_WebConfigConfigurationFile Include="@(_WebConfigConfiguration->'Web.%(Identity).config')" >
+      <DependentUpon Condition="EXISTS('Web.config')">Web.config</DependentUpon>
+      <CurrentConfiguration>false</CurrentConfiguration>
+      <CurrentConfiguration Condition="'$(Configuration)'=='%(Configuration)'">true</CurrentConfiguration>
+      <!-- The following could be extended to allow applying transforms based on the configuration in a hierarchical way. See notes in PR #68 -->
+      <!--<ApplyConfiguration>false</ApplyConfiguration>
+      <ApplyConfiguration Condition="'$(Configuration)'=='%(Configuration)'">true</ApplyConfiguration>
+      <ApplyConfiguration Condition="$(Configuration.StartsWith('%(Configuration).'))">true</ApplyConfiguration>-->
+    </_WebConfigConfigurationFile>
+    <None Include="@(_WebConfigConfigurationFile->Exists())" />
     <None Include="Web.BindingRedirects.config" Condition="EXISTS('Web.BindingRedirects.config')">
-      <DependentUpon>Web.config</DependentUpon>
+      <DependentUpon Condition="EXISTS('Web.config')">Web.config</DependentUpon>
     </None>
     
     <!-- Altered web.*.config inclusion so these items will be in the WebDeploy Package 

--- a/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/MSBuild.SDK.SystemWeb.DefaultItems.props
@@ -8,10 +8,12 @@
   
   <ItemGroup Condition="'$(EnableWebFormsDefaultItems)'=='true'">
     <Content Include="Web.config" />
-    <_WebConfigConfigurations Include="$(Configurations)" />
-    <None Include="@(_WebConfigConfigurations->'Web.%(Identity).config')">
+    <!-- web.*.config where * is a Configuration type (used for transforms) fixes #67 -->
+    <_WebConfigConfiguration Include="$(Configurations)" Exclude="@ExcludeWebConfigConfiguration" />
+    <_WebConfigConfigurationFiles Include="@(_WebConfigConfiguration->'Web.%(Identity).config')">
       <DependentUpon>Web.config</DependentUpon>
-    </None>
+    </_WebConfigConfigurationFiles>
+    <None Include="@(_WebConfigConfigurationFiles->Exists())" />
     <None Include="Web.BindingRedirects.config" Condition="EXISTS('Web.BindingRedirects.config')">
       <DependentUpon>Web.config</DependentUpon>
     </None>


### PR DESCRIPTION
Ensures that web.*.config files automatically included in None for each configuration, actually exist on disk to prevent missing files showing in the solution tree and issues with TVFS.

This should resolve #67