### PR TITLE
Enable simple replacement for Microsoft.WebApplication.targets

### DIFF
--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
@@ -18,6 +18,7 @@
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <WebApplicationsPath Condition=" '$(WebApplicationsPath)' == '' ">$(VSToolsPath)\WebApplications</WebApplicationsPath>
   </PropertyGroup>
 
   <!-- Default item excludes -->
@@ -28,5 +29,5 @@
   <!-- Inject BindingRedirects targets after Microsoft.NET.Sdk is injected -->
   <Import Project="MSBuild.SDK.SystemWeb.BindingRedirects.targets" />
 
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(WebApplicationsPath)\Microsoft.WebApplication.targets" />
 </Project>

--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.targets
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <WebApplicationsPath Condition=" '$(WebApplicationsPath)' == '' ">$(VSToolsPath)\WebApplications</WebApplicationsPath>
+    <WebApplicationsTargetPath Condition=" '$(WebApplicationsTargetPath)' == '' ">$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets</WebApplicationsTargetPath>
   </PropertyGroup>
 
   <!-- Default item excludes -->
@@ -29,5 +29,5 @@
   <!-- Inject BindingRedirects targets after Microsoft.NET.Sdk is injected -->
   <Import Project="MSBuild.SDK.SystemWeb.BindingRedirects.targets" />
 
-  <Import Project="$(WebApplicationsPath)\Microsoft.WebApplication.targets" />
+  <Import Project="$(WebApplicationsTargetPath)" />
 </Project>


### PR DESCRIPTION
Right now, there is a requirement to use msbuild due to the need of Microsoft.WebApplication.targets. This adds an override so that it can be replaced externally to this project.