### PR TITLE
Add SDK detection properties `UsingMSBuildSDKSystemWeb` and `UsingMSBuildSDKSystemWebRazor`

### DIFF
--- a/src/MSBuild.SDK.SystemWeb.RazorLibrary/Sdk/Sdk.props
+++ b/src/MSBuild.SDK.SystemWeb.RazorLibrary/Sdk/Sdk.props
@@ -1,5 +1,7 @@
 ﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
+  <PropertyGroup>
+    <UsingMSBuildSDKSystemWebRazor>true</UsingMSBuildSDKSystemWebRazor>
+  </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <Import Project="MSBuild.SDK.SystemWeb.RazorLibrary.DefaultPackages.props"/>

--- a/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
+++ b/src/MSBuild.SDK.SystemWeb/Sdk/Sdk.props
@@ -1,4 +1,7 @@
 ﻿<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <UsingMSBuildSDKSystemWeb>true</UsingMSBuildSDKSystemWeb>
+  </PropertyGroup>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Add SDK detection properties `UsingMSBuildSDKSystemWeb` and `UsingMSBuildSDKSystemWebRazor`

This is to 'mimic' the properties `UsingMicrosoftNETSdkWeb` and `UsingMicrosoftNETSdkRazor` to allow easy detection of the SDK in use.