### PR TITLE
Fix Markdown syntax in RazorLibrary.md

### DIFF
--- a/docs/RazorLibrary.md
+++ b/docs/RazorLibrary.md
@@ -60,6 +60,7 @@ For more information see
 | `OverwriteAppConfigWithBindingRedirects` | false | If set, then any [automatically generated binding redirects](Binding_Redirects/Autogenerating-Binding-Redirects.md) will be copied into your web.config and `RazorAppConfigFiles` files. |
 
 ### Deprecated Properties
+
 | Property | Default value | Description |
 | -------- | ------------- | ----------- |
 | `ExcludeDefaultRazorPackages` | false | Use `ExcludeSDKDefaultPackages` instead  |


### PR DESCRIPTION
Currently the table Deprecated Properties is formatted wrongly on the website:
 https://czemacleod.github.io/MSBuild.SDK.SystemWeb/RazorLibrary.html#deprecated-properties
  
<img width="1011" height="110" alt="image" src="https://github.com/user-attachments/assets/c8a62f8e-b379-4fcd-8d3d-f1b9c87710cb" />
